### PR TITLE
获取不到authorCode时，脚本报错退出

### DIFF
--- a/jd_cash.js
+++ b/jd_cash.js
@@ -520,7 +520,7 @@ function shareCodesFormat() {
       console.log(`由于您第${$.index}个京东账号未提供shareCode,将采纳本脚本自带的助力码\n`)
       const tempIndex = $.index > inviteCodes.length ? (inviteCodes.length - 1) : ($.index - 1);
       $.newShareCodes = inviteCodes[tempIndex].split('@');
-      let authorCode = deepCopy($.authorCode)
+      let authorCode = deepCopy($.authorCode) || []
       $.newShareCodes = [...(authorCode.map((item, index) => authorCode[index] = item['inviteCode'])), ...$.newShareCodes];
     }
     const readShareCodeRes = await readShareCode();


### PR DESCRIPTION
(node:95530) UnhandledPromiseRejectionWarning: TypeError: authorCode.map is not a function or its return value is not iterable
    at /jd/scripts/jd_cash.js:524:41
    at new Promise (<anonymous>)
    at shareCodesFormat (/jd/scripts/jd_cash.js:514:10)
    at jdCash (/jd/scripts/jd_cash.js:92:9)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async /jd/scripts/jd_cash.js:72:7
(Use `node --trace-warnings ...` to show where the warning was created)
(node:95530) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:95530) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
